### PR TITLE
guard 2.0 is not compatible with this.

### DIFF
--- a/guard-prove.gemspec
+++ b/guard-prove.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'guard-prove'
   
-  s.add_dependency 'guard', '>= 1.1.1'
+  s.add_dependency 'guard', '~> 1'
   s.add_dependency 'systemu', '>= 1.2.0'
   
   s.add_development_dependency 'bundler', '~> 1.0.7'


### PR DESCRIPTION
Indicate that 2.0 is not compatible by only letting this dependency range in the 1.x.x range.  not as precise as >= 1.1.1 but prevents getting tangled up in guard 2.0 incompatibilities.